### PR TITLE
fix `inputManager` and `skipMessage`

### DIFF
--- a/app/src/main/java/nep/timeline/cirno/hooks/android/broadcast/BroadcastSkipHook.java
+++ b/app/src/main/java/nep/timeline/cirno/hooks/android/broadcast/BroadcastSkipHook.java
@@ -6,9 +6,10 @@ import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedHelpers;
 import nep.timeline.cirno.framework.AbstractMethodHook;
 import nep.timeline.cirno.framework.MethodHook;
+import nep.timeline.cirno.log.Log;
 import nep.timeline.cirno.services.ProcessService;
-import nep.timeline.cirno.utils.SystemChecker;
 import nep.timeline.cirno.virtuals.ProcessRecord;
+import nep.timeline.cirno.utils.SystemChecker;
 
 public class BroadcastSkipHook extends MethodHook {
     public BroadcastSkipHook(ClassLoader classLoader) {
@@ -26,10 +27,10 @@ public class BroadcastSkipHook extends MethodHook {
     }
 
     @Override
-    public Object[] getTargetParam() {
+    public Object[] getTargetParam() {        
         if (SystemChecker.isVivo(classLoader))
             return new Object[] { "com.android.server.am.BroadcastRecord", "com.android.server.am.BroadcastFilter", boolean.class, int.class, "com.android.server.am.IVivoBroadcastQueueModern" };
-        return new Object[] { "com.android.server.am.BroadcastRecord", "com.android.server.am.BroadcastFilter" };
+        return new Object[] { "com.android.server.am.BroadcastRecord", "com.android.server.am.BroadcastFilter", boolean.class };
     }
 
     @Override
@@ -37,27 +38,39 @@ public class BroadcastSkipHook extends MethodHook {
         return new AbstractMethodHook() {
             @Override
             protected void afterMethod(MethodHookParam param) {
-                if (param.getResult() != null)
-                    return;
+                try {
+                    // ✅ 安全地获取返回值
+                    Object result = param.getResult();
+                    if (result != null) {
+                        return;
+                    }
 
-                Object filter = param.args[1];
-                if (filter == null)
-                    return;
+                    Object filter = param.args[1];
+                    if (filter == null) {
+                        return;
+                    }
 
-                Object receiver = XposedHelpers.getObjectField(filter, "receiverList");
-                if (receiver == null)
-                    return;
+                    Object receiver = XposedHelpers.getObjectField(filter, "receiverList");
+                    if (receiver == null) {
+                        return;
+                    }
 
-                Object app = XposedHelpers.getObjectField(receiver, "app");
-                if (app == null)
-                    return;
+                    Object app = XposedHelpers.getObjectField(receiver, "app");
+                    if (app == null) {
+                        return;
+                    }
 
-                ProcessRecord processRecord = ProcessService.getProcessRecord(app);
-                if (processRecord == null)
-                    return;
+                    ProcessRecord processRecord = ProcessService.getProcessRecord(app);
+                    if (processRecord == null) {
+                        return;
+                    }
 
-                if (processRecord.isFrozen())
-                    param.setResult("Skipping deliver [Cirno]: frozen process");
+                    if (processRecord.isFrozen()) {
+                        param.setResult("Skipping deliver [Cirno]: frozen process");
+                    }
+                } catch (Exception e) {
+                    Log.e("BroadcastSkipHook 处理失败", e);
+                }
             }
         };
     }

--- a/app/src/main/java/nep/timeline/cirno/hooks/android/input/InputMethodManagerService.java
+++ b/app/src/main/java/nep/timeline/cirno/hooks/android/input/InputMethodManagerService.java
@@ -3,13 +3,16 @@ package nep.timeline.cirno.hooks.android.input;
 import android.os.Build;
 import android.view.inputmethod.InputMethodInfo;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 
 import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import nep.timeline.cirno.entity.AppRecord;
 import nep.timeline.cirno.framework.AbstractMethodHook;
 import nep.timeline.cirno.framework.MethodHook;
+import nep.timeline.cirno.log.Log;
 import nep.timeline.cirno.services.ActivityManagerService;
 import nep.timeline.cirno.services.AppService;
 import nep.timeline.cirno.services.FreezerService;
@@ -33,7 +36,7 @@ public class InputMethodManagerService extends MethodHook {
 
     @Override
     public Object[] getTargetParam() {
-        return new Object[] { String.class, int.class };
+        return new Object[0];
     }
 
     @Override
@@ -42,51 +45,123 @@ public class InputMethodManagerService extends MethodHook {
             @Override
             @SuppressWarnings("unchecked")
             protected void beforeMethod(MethodHookParam param) {
-                String id = (String) param.args[0];
-                if (id == null)
-                    return;
-
-                int userId = ActivityManagerService.getCurrentOrTargetUserId();
-                Object settings = (Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE) ? XposedHelpers.callStaticMethod(XposedHelpers.findClassIfExists("com.android.server.inputmethod.InputMethodSettingsRepository", classLoader), "get", userId) : XposedHelpers.getObjectField(param.thisObject, "mSettings");
-
-                synchronized (InputMethodData.class) {
-                    if (InputMethodData.instance == null) {
-                        InputMethodData.instance = param.thisObject;
-                        if (settings != null) {
-                            Object map = XposedHelpers.getObjectField(settings, "mMethodMap");
-                            if (map != null) {
-                                if (map.getClass().getTypeName().equals("com.android.server.inputmethod.InputMethodMap"))
-                                    InputMethodData.inputMethods = (Map<String, InputMethodInfo>) XposedHelpers.getObjectField(map, "mMap");
-                                else
-                                    InputMethodData.inputMethods = (Map<String, InputMethodInfo>) map;
-                            }
-                            else
-                                InputMethodData.inputMethods = null;
-                        }
-                        else
-                            InputMethodData.inputMethods = null;
-                    }
-
-                    Map<String, InputMethodInfo> inputMethodMap = InputMethodData.inputMethods;
-                    if (inputMethodMap == null)
+                try {
+                    if (param.args.length < 1) {
                         return;
+                    }
 
-                    InputMethodInfo inputMethodInfo = inputMethodMap.get(id);
+                    Object arg0 = param.args[0];
+                    if (!(arg0 instanceof String)) {
+                        return;
+                    }
 
-                    if (inputMethodInfo != null && !inputMethodInfo.equals(InputMethodData.currentInputMethodInfo)) {
-                        InputMethodData.currentInputMethodInfo = inputMethodInfo;
-                        AppRecord appRecord = AppService.get(inputMethodInfo.getPackageName(), userId);
-                        if (appRecord != InputMethodData.currentInputMethodApp) {
-                            AppRecord oldApp = InputMethodData.currentInputMethodApp;
-                            InputMethodData.currentInputMethodApp = appRecord;
-                            if (appRecord != null)
-                                FreezerService.thaw(appRecord);
-                            if (oldApp != null)
-                                FreezerHandler.sendFreezeMessage(oldApp, 3000);
+                    String id = (String) arg0;
+                    if (id == null || id.isEmpty()) {
+                        return;
+                    }
+
+                    int userId = ActivityManagerService.getCurrentOrTargetUserId();
+                    
+                    Object settings = null;
+                    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                        try {
+                            settings = XposedHelpers.callStaticMethod(
+                                XposedHelpers.findClassIfExists(
+                                    "com.android.server.inputmethod.InputMethodSettingsRepository", 
+                                    classLoader), 
+                                "get", userId);
+                        } catch (Exception e) {
+                            Log.w("获取 InputMethodSettingsRepository 失败");
+                        }
+                    } else {
+                        try {
+                            settings = XposedHelpers.getObjectField(param.thisObject, "mSettings");
+                        } catch (Exception e) {
+                            Log.w("获取 mSettings 失败");
                         }
                     }
+
+                    synchronized (InputMethodData.class) {
+                        if (InputMethodData.instance == null) {
+                            InputMethodData.instance = param.thisObject;
+                            if (settings != null) {
+                                try {
+                                    Object map = XposedHelpers.getObjectField(settings, "mMethodMap");
+                                    if (map != null) {
+                                        if (map.getClass().getTypeName().equals("com.android.server.inputmethod.InputMethodMap")) {
+                                            InputMethodData.inputMethods = (Map<String, InputMethodInfo>) 
+                                                XposedHelpers.getObjectField(map, "mMap");
+                                        } else {
+                                            InputMethodData.inputMethods = (Map<String, InputMethodInfo>) map;
+                                        }
+                                    } else {
+                                        InputMethodData.inputMethods = null;
+                                    }
+                                } catch (Exception e) {
+                                    InputMethodData.inputMethods = null;
+                                }
+                            } else {
+                                InputMethodData.inputMethods = null;
+                            }
+                        }
+
+                        Map<String, InputMethodInfo> inputMethodMap = InputMethodData.inputMethods;
+                        if (inputMethodMap == null) {
+                            return;
+                        }
+
+                        InputMethodInfo inputMethodInfo = inputMethodMap.get(id);
+
+                        if (inputMethodInfo != null && !inputMethodInfo.equals(InputMethodData.currentInputMethodInfo)) {
+                            InputMethodData.currentInputMethodInfo = inputMethodInfo;
+                            AppRecord appRecord = AppService.get(inputMethodInfo.getPackageName(), userId);
+                            if (appRecord != InputMethodData.currentInputMethodApp) {
+                                AppRecord oldApp = InputMethodData.currentInputMethodApp;
+                                InputMethodData.currentInputMethodApp = appRecord;
+                                if (appRecord != null) {
+                                    FreezerService.thaw(appRecord);
+                                }
+                                if (oldApp != null) {
+                                    FreezerHandler.sendFreezeMessage(oldApp, 3000);
+                                }
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    Log.e("InputMethodManagerService 处理失败", e);
                 }
             }
         };
+    }
+
+    @Override
+    public void startHook() {
+        try {
+            Class<?> targetClass = XposedHelpers.findClass(getTargetClass(), classLoader);
+            
+            boolean hooked = false;
+            for (Method method : targetClass.getDeclaredMethods()) {
+                if (method.getName().equals(getTargetMethod())) {
+                    try {
+                        XposedBridge.hookMethod(method, getTargetHook());
+                        Log.i(method.getName() + " [参数: " + method.getParameterCount() + "] -> 成功Hook完毕!");
+                        hooked = true;
+                    } catch (Exception e) {
+                        Log.w("Hook " + method.getName() + " [参数: " + method.getParameterCount() + "] 失败");
+                    }
+                }
+            }
+            
+            if (!hooked) {
+                Log.w("未能 Hook 任何 setInputMethodLocked 方法");
+            }
+        } catch (Throwable e) {
+            Log.e(getTargetMethod() + " Hook 失败", e);
+        }
+    }
+
+    @Override
+    public boolean isIgnoreError() {
+        return true;
     }
 }


### PR DESCRIPTION
The edit of `inputManager` is Multi-hook params, maybe it's a little inefficient and comes with performance overhead.

The vivo special supporting code of `skipMessage` is not tested. Maybe it needs to be fixed too.