### PR TITLE
fix(RWFrozen): under a16 thaw problem

### DIFF
--- a/app/src/main/java/nep/timeline/cirno/utils/FrozenRW.java
+++ b/app/src/main/java/nep/timeline/cirno/utils/FrozenRW.java
@@ -16,7 +16,7 @@ public class FrozenRW {
 
     private static void writeFrozen(int uid, int pid, int frozenState) {
         if (!cgroupV2SysAppIsolated) {
-            RWUtils.writeFrozen(cgroupV2 + "/uid_" + uid + "/pid_" + pid + "/cgroup.freeze", 1);
+            RWUtils.writeFrozen(cgroupV2 + "/uid_" + uid + "/pid_" + pid + "/cgroup.freeze", frozenState);
             return;
         }
 


### PR DESCRIPTION
you wrote `1` instead of `frozenState` mistakenly. it makes all `.thaw()` methods couldn't work.